### PR TITLE
Hazelcast Homebrew 5.8.0-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise-snapshot.rb
+++ b/hazelcast-enterprise-snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseSnapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "ca4bdcbe089dd51964c6c776f6488abf09af6b532c0b159c2a7dd670e0c2047f"
+    sha256 "72ea39eaa9fa0b9475ddf2a398898fafa0ad43a3b128e38e93749f3249798dcf"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"

--- a/hazelcast-enterprise@5.8.0.snapshot.rb
+++ b/hazelcast-enterprise@5.8.0.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT580Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "ca4bdcbe089dd51964c6c776f6488abf09af6b532c0b159c2a7dd670e0c2047f"
+    sha256 "72ea39eaa9fa0b9475ddf2a398898fafa0ad43a3b128e38e93749f3249798dcf"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.6.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/27808252220/job/82292607399.